### PR TITLE
Drop "type: module" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tctx",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "W3C Trace Contexts made simple",
 	"keywords": [
 		"tracecontext",
@@ -13,7 +13,6 @@
 	"license": "MIT",
 	"author": "Marais Rossow <me@marais.dev> (https://marais.io)",
 	"sideEffects": false,
-	"type": "module",
 	"exports": {
 		".": {
 			"import": "./index.mjs",


### PR DESCRIPTION
Hey @maraisr 👋 

Thank you so much for all your awesome projects ❤️ 

I'm facing an issue with trying to import this lib from a CommonJs app. 
It's basically the same issue that was present in `diary`: https://github.com/maraisr/diary/pull/23

That's why I just took the same solution of dropping the `type: module` from the `package.json` as you did here:
https://github.com/maraisr/diary/commit/7f70ccdd6a50612a58133b2f6868c96a19ded7eb

Let me know if you need any further information 👍 